### PR TITLE
Migrate to ruff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
         run: pytest
       - name: Lint
         run: pylint yocto_fetcher test
+      - name: Lint (ruff)
+        run: ruff check --output-format=github .
 
   formatting:
     name: formatting
@@ -30,7 +32,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@main
-      - name: Check formatting
-        uses: AlexanderMelde/yapf-action@master
+      - name: Setup Python
+        uses: actions/setup-python@main
         with:
-          args: --verbose
+          python-version: "3.12"
+          cache: 'pip'
+      - name: Setup
+        run: pip install ".[dev]"
+      - name: Check Formatting
+        run: ruff format --check --diff .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ yoctofetcher = "yocto_fetcher.__main__:main"
 dev = [
     "pylint == 3.0.3",
     "pytest == 7.4.4",
-    "yapf == 0.40.2"
+    "ruff == 0.1.11"
 ]
 
 [build-system]
@@ -37,8 +37,3 @@ version = {attr = "yocto_fetcher.version.__version__"}
 [tool.setuptools.packages.find]
 include = ["yocto_fetcher"]
 
-[tool.yapf]
-based_on_style = "pep8"
-spaces_before_comment = 4
-split_before_logical_operator = true
-column_limit = 79

--- a/test/test_gitfetcher.py
+++ b/test/test_gitfetcher.py
@@ -28,16 +28,15 @@ from yocto_fetcher.gitfetcher import GitFetcher
 
 
 class TestGitFetcher(unittest.TestCase):
-
     def test_project_name_is_split_from_url(self):
         self.assertEqual(
             "projA",
-            GitFetcher("https://gitrepo.com/ab/projA",
-                       MagicMock()).project_name)
+            GitFetcher("https://gitrepo.com/ab/projA", MagicMock()).project_name,
+        )
         self.assertEqual(
             "projB",
-            GitFetcher("https://gitrepo.com/ab/projB",
-                       MagicMock()).project_name)
+            GitFetcher("https://gitrepo.com/ab/projB", MagicMock()).project_name,
+        )
 
     def test_project_name_throws_if_no_match_found(self):
         with self.assertRaises(ValueError):
@@ -46,12 +45,14 @@ class TestGitFetcher(unittest.TestCase):
     def test_dest_file_name(self):
         self.assertEqual(
             "git2_gitrepo.org.xyz.proj0.git.tar.gz",
-            GitFetcher("https://gitrepo.org/xyz/proj0.git",
-                       MagicMock()).dest_filename)
+            GitFetcher("https://gitrepo.org/xyz/proj0.git", MagicMock()).dest_filename,
+        )
         self.assertEqual(
             "git2_gitrepo.org.x.y_z.p_r.o.j.0.git.tar.gz",
-            GitFetcher("https://gitrepo.org/x:y z/p r/o/j*0.git",
-                       MagicMock()).dest_filename)
+            GitFetcher(
+                "https://gitrepo.org/x:y z/p r/o/j*0.git", MagicMock()
+            ).dest_filename,
+        )
 
     @patch("subprocess.check_call", autospec=True)
     def test_fetch_clones_to_path(self, mock_call):
@@ -60,12 +61,15 @@ class TestGitFetcher(unittest.TestCase):
         fetcher.fetch()
         mock_call.assert_called_once_with(
             ["git", "clone", "--bare", "--mirror", "https://x.y/a/bc", "bc"],
-            cwd=workdir)
+            cwd=workdir,
+        )
 
     @patch("subprocess.check_call", autospec=True)
-    @patch("subprocess.check_output",
-           autospec=True,
-           return_value="Tue, 20 Jun 2023 11:22:33 +0000")
+    @patch(
+        "subprocess.check_output",
+        autospec=True,
+        return_value="Tue, 20 Jun 2023 11:22:33 +0000",
+    )
     def test_pack_creates_targz(self, mock_mtime, mock_call):
         workdir = MagicMock()
         fetcher = GitFetcher("https://x.y/a/proj-x", workdir)
@@ -74,11 +78,21 @@ class TestGitFetcher(unittest.TestCase):
 
         mock_mtime.assert_called_once_with(
             ["git", "log", "--all", "-1", "--format=%cD"],
-            cwd=os.path.join(workdir, "proj-x"))
-        mock_call.assert_called_once_with([
-            "tar", "-czf",
-            os.path.join("dest/dir", "git2_x.y.a.proj-x.tar.gz"), "--owner",
-            "oe:0", "--group", "oe:0", "--mtime",
-            "Tue, 20 Jun 2023 11:22:33 +0000", "."
-        ],
-                                          cwd=os.path.join(workdir, "proj-x"))
+            cwd=os.path.join(workdir, "proj-x"),
+        )
+        # pylint: disable=duplicate-code
+        mock_call.assert_called_once_with(
+            [
+                "tar",
+                "-czf",
+                os.path.join("dest/dir", "git2_x.y.a.proj-x.tar.gz"),
+                "--owner",
+                "oe:0",
+                "--group",
+                "oe:0",
+                "--mtime",
+                "Tue, 20 Jun 2023 11:22:33 +0000",
+                ".",
+            ],
+            cwd=os.path.join(workdir, "proj-x"),
+        )

--- a/yocto_fetcher/__main__.py
+++ b/yocto_fetcher/__main__.py
@@ -31,12 +31,15 @@ from yocto_fetcher.version import __version__
 def parse_args():
     parser = argparse.ArgumentParser(
         prog="yocto-fetcher",
-        description="Create Yocto Bitbake compatible source tarballs")
-    parser.add_argument('--version',
-                        '-v',
-                        action='version',
-                        version=f"%(prog)s {__version__}",
-                        help='Shows the program version')
+        description="Create Yocto Bitbake compatible source tarballs",
+    )
+    parser.add_argument(
+        "--version",
+        "-v",
+        action="version",
+        version=f"%(prog)s {__version__}",
+        help="Shows the program version",
+    )
     parser.add_argument("source")
     return parser.parse_args()
 
@@ -50,5 +53,5 @@ def main():
         fetcher.pack(os.getcwd())
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/yocto_fetcher/gitfetcher.py
+++ b/yocto_fetcher/gitfetcher.py
@@ -26,7 +26,6 @@ from urllib.parse import urlparse
 
 
 class GitFetcher:
-
     def __init__(self, repo_url, workdir):
         self.repo_url = repo_url
         self.workdir = workdir
@@ -36,28 +35,39 @@ class GitFetcher:
         if not self.project_name:
             raise ValueError(f"Invalid url: {repo_url}")
 
-        path_escaped = url.path.replace("/", ".").replace("*", ".").replace(
-            ":", ".").replace(" ", "_")
+        path_escaped = (
+            url.path.replace("/", ".")
+            .replace("*", ".")
+            .replace(":", ".")
+            .replace(" ", "_")
+        )
         self.dest_filename = f"git2_{url.netloc}{path_escaped}.tar.gz"
 
     def fetch(self):
-        subprocess.check_call([
-            "git", "clone", "--bare", "--mirror", self.repo_url,
-            self.project_name
-        ],
-                              cwd=self.workdir)
+        subprocess.check_call(
+            ["git", "clone", "--bare", "--mirror", self.repo_url, self.project_name],
+            cwd=self.workdir,
+        )
 
     def pack(self, dest_dir):
-        subprocess.check_call([
-            "tar", "-czf",
-            os.path.join(dest_dir, self.dest_filename), "--owner", "oe:0",
-            "--group", "oe:0", "--mtime",
-            self.__query_mtime(), "."
-        ],
-                              cwd=os.path.join(self.workdir,
-                                               self.project_name))
+        subprocess.check_call(
+            [
+                "tar",
+                "-czf",
+                os.path.join(dest_dir, self.dest_filename),
+                "--owner",
+                "oe:0",
+                "--group",
+                "oe:0",
+                "--mtime",
+                self.__query_mtime(),
+                ".",
+            ],
+            cwd=os.path.join(self.workdir, self.project_name),
+        )
 
     def __query_mtime(self):
         return subprocess.check_output(
             ["git", "log", "--all", "-1", "--format=%cD"],
-            cwd=os.path.join(self.workdir, self.project_name))
+            cwd=os.path.join(self.workdir, self.project_name),
+        )


### PR DESCRIPTION
Migrates formatting from yapf to ruff (incl. reformat) and adds ruff check as additional CI check.