### PR TITLE
Install dependencies on CodeQL CI builds to avoid caching issues

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,6 +16,8 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'pip'
+      - name: Install Dependencies
+        run: pip install ".[dev]"
       - name: CodeQL Initialization
         uses: github/codeql-action/init@v3
         with:


### PR DESCRIPTION
An empty cache fails due to

```
Error: Cache folder path is retrieved for pip but doesn't exist on disk: /home/runner/.cache/pip
```
This has been reported upstream; the workaround is to install some dependencies.