### PR TITLE
Update Pytest 9.0.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ yoctofetcher = "yocto_fetcher.__main__:main"
 [project.optional-dependencies]
 dev = [
     "pylint == 3.3.9",
-    "pytest == 8.4.2",
+    "pytest == 9.0.3",
     "ruff == 0.15.13",
     "pyrefly==1.0.0"
 ]


### PR DESCRIPTION
Fixes CVE-2025-71176, vulnerable tmpdir handling.